### PR TITLE
feat: add ERC-7579 adapter support to Safe4337Pack

### DIFF
--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.test.ts
@@ -364,6 +364,125 @@ describe('Safe4337Pack', () => {
     })
   })
 
+  describe('ERC-7579 support', () => {
+    const erc7579Config = {
+      safe4337ModuleAddress: '0x7579EE8307284F293B1927136486880611F20002',
+      launchpadAddress: '0x7579011aB74c46090561ea277Ba79D510c6C00ff',
+      attesters: ['0x000000000069E2a187AEFFb852bE3dF9Ea2806DB'],
+      attestersThreshold: 1,
+      validators: [
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          context: '0x'
+        }
+      ]
+    }
+
+    it('should throw if safe4337ModuleAddress is missing from erc7579 config', async () => {
+      await expect(
+        createSafe4337Pack({
+          options: { owners: [fixtures.OWNER_1], threshold: 1 },
+          safeModulesVersion: '0.3.0',
+          erc7579: {
+            ...erc7579Config,
+            safe4337ModuleAddress: ''
+          }
+        })
+      ).rejects.toThrow(
+        'ERC-7579 configuration requires both safe4337ModuleAddress and launchpadAddress'
+      )
+    })
+
+    it('should throw if launchpadAddress is missing from erc7579 config', async () => {
+      await expect(
+        createSafe4337Pack({
+          options: { owners: [fixtures.OWNER_1], threshold: 1 },
+          safeModulesVersion: '0.3.0',
+          erc7579: {
+            ...erc7579Config,
+            launchpadAddress: ''
+          }
+        })
+      ).rejects.toThrow(
+        'ERC-7579 configuration requires both safe4337ModuleAddress and launchpadAddress'
+      )
+    })
+
+    it('should throw if no attesters are provided', async () => {
+      await expect(
+        createSafe4337Pack({
+          options: { owners: [fixtures.OWNER_1], threshold: 1 },
+          safeModulesVersion: '0.3.0',
+          erc7579: {
+            ...erc7579Config,
+            attesters: []
+          }
+        })
+      ).rejects.toThrow(
+        'ERC-7579 configuration requires at least one attester and a non-zero attestersThreshold'
+      )
+    })
+
+    it('should enable both the 7579 module and launchpad in the setup transaction', async () => {
+      const encodeFunctionDataSpy = jest.spyOn(viem, 'encodeFunctionData')
+
+      await createSafe4337Pack({
+        options: { owners: [fixtures.OWNER_1], threshold: 1 },
+        safeModulesVersion: '0.3.0',
+        erc7579: erc7579Config
+      })
+
+      expect(encodeFunctionDataSpy).toHaveBeenCalledWith({
+        abi: constants.ABI,
+        functionName: 'enableModules',
+        args: [[erc7579Config.safe4337ModuleAddress, erc7579Config.launchpadAddress]]
+      })
+    })
+
+    it('should include the launchpad initSafe7579 call in the setup batch', async () => {
+      const encodeFunctionDataSpy = jest.spyOn(viem, 'encodeFunctionData')
+
+      await createSafe4337Pack({
+        options: { owners: [fixtures.OWNER_1], threshold: 1 },
+        safeModulesVersion: '0.3.0',
+        erc7579: erc7579Config
+      })
+
+      expect(encodeFunctionDataSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          functionName: 'initSafe7579',
+          args: expect.arrayContaining([
+            erc7579Config.safe4337ModuleAddress,
+            erc7579Config.validators!.map((v) => ({
+              module: v.address,
+              initData: v.context
+            }))
+          ])
+        })
+      )
+    })
+
+    it('should use the 7579 module address as the fallbackHandler', async () => {
+      const safeCreateSpy = jest.spyOn(Safe, 'init')
+
+      await createSafe4337Pack({
+        options: { owners: [fixtures.OWNER_1], threshold: 1 },
+        safeModulesVersion: '0.3.0',
+        erc7579: erc7579Config
+      })
+
+      expect(safeCreateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          predictedSafe: expect.objectContaining({
+            safeAccountConfig: expect.objectContaining({
+              fallbackHandler: erc7579Config.safe4337ModuleAddress
+            })
+          })
+        })
+      )
+    })
+  })
+
   describe('When creating a new SafeOperation', () => {
     let safe4337Pack: Safe4337Pack
     let transferUSDC: MetaTransactionData

--- a/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
+++ b/packages/relay-kit/src/packs/safe-4337/Safe4337Pack.ts
@@ -60,7 +60,8 @@ import {
   ABI,
   DEFAULT_SAFE_VERSION,
   DEFAULT_SAFE_MODULES_VERSION,
-  RPC_4337_CALLS
+  RPC_4337_CALLS,
+  ERC7579_LAUNCHPAD_ABI
 } from './constants'
 import {
   entryPointToSafeModules,
@@ -390,7 +391,8 @@ export class Safe4337Pack extends RelayKitBasePack<{
       bundlerUrl,
       customContracts,
       paymasterOptions,
-      onchainAnalytics
+      onchainAnalytics,
+      erc7579
     } = initOptions
 
     let protocolKit: Safe
@@ -425,6 +427,20 @@ export class Safe4337Pack extends RelayKitBasePack<{
       throw new Error(
         `Safe4337Module and/or SafeModuleSetup not available for chain ${network} and modules version ${safeModulesVersion}`
       )
+    }
+
+    if (erc7579) {
+      if (!erc7579.safe4337ModuleAddress || !erc7579.launchpadAddress) {
+        throw new Error(
+          'ERC-7579 configuration requires both safe4337ModuleAddress and launchpadAddress'
+        )
+      }
+      if (!erc7579.attesters?.length || !erc7579.attestersThreshold) {
+        throw new Error(
+          'ERC-7579 configuration requires at least one attester and a non-zero attestersThreshold'
+        )
+      }
+      safe4337ModuleAddress = erc7579.safe4337ModuleAddress
     }
 
     let safeWebAuthnSharedSignerAddress = customContracts?.safeWebAuthnSharedSignerAddress
@@ -473,23 +489,66 @@ export class Safe4337Pack extends RelayKitBasePack<{
 
       // we need to create a batch to setup the 4337 Safe Account
 
-      // first setup transaction: Enable 4337 module
-      const enable4337ModuleTransaction = {
+      const modulesToEnable: string[] = [safe4337ModuleAddress]
+
+      if (erc7579) {
+        modulesToEnable.push(erc7579.launchpadAddress)
+      }
+
+      // first setup transaction: Enable 4337 module (and launchpad if ERC-7579)
+      const enableModulesTransaction = {
         to: safeModulesSetupAddress,
         value: '0',
         data: encodeFunctionData({
           abi: ABI,
           functionName: 'enableModules',
-          args: [[safe4337ModuleAddress]]
+          args: [modulesToEnable]
         }),
-        operation: OperationType.DelegateCall // DelegateCall required for enabling the 4337 module
+        operation: OperationType.DelegateCall
       }
 
-      const setupTransactions = [enable4337ModuleTransaction]
+      const setupTransactions = [enableModulesTransaction]
+
+      if (erc7579) {
+        const { launchpadAddress, validators, executors, fallbacks, hooks, attesters, attestersThreshold } = erc7579
+
+        const initData = encodeFunctionData({
+          abi: ERC7579_LAUNCHPAD_ABI,
+          functionName: 'initSafe7579',
+          args: [
+            safe4337ModuleAddress as `0x${string}`,
+            (validators || []).map((v) => ({
+              module: v.address as `0x${string}`,
+              initData: v.context as `0x${string}`
+            })),
+            (executors || []).map((e) => ({
+              module: e.address as `0x${string}`,
+              initData: e.context as `0x${string}`
+            })),
+            (fallbacks || []).map((f) => ({
+              module: f.address as `0x${string}`,
+              initData: f.context as `0x${string}`
+            })),
+            (hooks || []).map((h) => ({
+              module: h.address as `0x${string}`,
+              initData: h.context as `0x${string}`
+            })),
+            attesters.map((a) => a as `0x${string}`),
+            attestersThreshold
+          ]
+        })
+
+        setupTransactions.push({
+          to: launchpadAddress,
+          value: '0',
+          data: initData,
+          operation: OperationType.DelegateCall
+        })
+      }
 
       // Initialize deployment variables early
-      let deploymentTo = enable4337ModuleTransaction.to
-      let deploymentData = enable4337ModuleTransaction.data
+      let deploymentTo = enableModulesTransaction.to
+      let deploymentData = enableModulesTransaction.data
 
       const isApproveTransactionRequired =
         !!paymasterOptions &&

--- a/packages/relay-kit/src/packs/safe-4337/constants.ts
+++ b/packages/relay-kit/src/packs/safe-4337/constants.ts
@@ -64,6 +64,52 @@ export const ENTRYPOINT_ABI = [
 export const ENTRYPOINT_ADDRESS_V06 = '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
 export const ENTRYPOINT_ADDRESS_V07 = '0x0000000071727De22E5E9d8BAf0edAc6f37da032'
 
+export const ERC7579_LAUNCHPAD_ABI = [
+  {
+    inputs: [
+      { name: 'safe7579', type: 'address' },
+      {
+        name: 'validators',
+        type: 'tuple[]',
+        components: [
+          { name: 'module', type: 'address' },
+          { name: 'initData', type: 'bytes' }
+        ]
+      },
+      {
+        name: 'executors',
+        type: 'tuple[]',
+        components: [
+          { name: 'module', type: 'address' },
+          { name: 'initData', type: 'bytes' }
+        ]
+      },
+      {
+        name: 'fallbacks',
+        type: 'tuple[]',
+        components: [
+          { name: 'module', type: 'address' },
+          { name: 'initData', type: 'bytes' }
+        ]
+      },
+      {
+        name: 'hooks',
+        type: 'tuple[]',
+        components: [
+          { name: 'module', type: 'address' },
+          { name: 'initData', type: 'bytes' }
+        ]
+      },
+      { name: 'attesters', type: 'address[]' },
+      { name: 'threshold', type: 'uint8' }
+    ],
+    name: 'initSafe7579',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  }
+] as const
+
 export enum RPC_4337_CALLS {
   ESTIMATE_USER_OPERATION_GAS = 'eth_estimateUserOperationGas',
   SEND_USER_OPERATION = 'eth_sendUserOperation',

--- a/packages/relay-kit/src/packs/safe-4337/types.ts
+++ b/packages/relay-kit/src/packs/safe-4337/types.ts
@@ -46,6 +46,22 @@ export type PaymasterOptions =
     ))
   | undefined
 
+export type Erc7579ModuleConfig = {
+  address: string
+  context: string
+}
+
+export type Erc7579Config = {
+  safe4337ModuleAddress: string
+  launchpadAddress: string
+  attesters: string[]
+  attestersThreshold: number
+  validators?: Erc7579ModuleConfig[]
+  executors?: Erc7579ModuleConfig[]
+  fallbacks?: Erc7579ModuleConfig[]
+  hooks?: Erc7579ModuleConfig[]
+}
+
 export type Safe4337InitOptions = {
   provider: SafeProviderConfig['provider']
   signer?: SafeProviderConfig['signer']
@@ -60,6 +76,7 @@ export type Safe4337InitOptions = {
   options: ExistingSafeOptions | PredictedSafeOptions
   paymasterOptions?: PaymasterOptions
   onchainAnalytics?: OnchainAnalyticsProps
+  erc7579?: Erc7579Config
 }
 
 export type Safe4337Options = {


### PR DESCRIPTION
## Summary

- Extends `Safe4337Pack.init()` to accept an optional `erc7579` configuration for deploying new Safe accounts with the ERC-7579 adapter (Safe7579)
- Enables users to install ERC-7579 modules (e.g. Rhinestone SmartSession for session keys) on Safe accounts created through the relay-kit
- All 7579 contract addresses (module, launchpad, attesters) are user-provided since they are chain-specific and not in the standard Safe module deployments registry

## Changes

**`types.ts`** — New `Erc7579Config` and `Erc7579ModuleConfig` types; `Safe4337InitOptions` extended with optional `erc7579` field

**`constants.ts`** — Added `ERC7579_LAUNCHPAD_ABI` for the `initSafe7579` setup call

**`Safe4337Pack.ts`** — Modified `init()` to:
- Validate the `erc7579` config (required addresses, attesters, threshold)
- Override the Safe4337 module address with the 7579-compatible module when `erc7579` is provided
- Enable both the 7579 module and launchpad via `enableModules`
- Encode the `initSafe7579` delegatecall to configure validators, executors, fallbacks, hooks, and attesters
- Existing Safe path automatically validates the 7579 module is enabled (via the overridden module address)

**`Safe4337Pack.test.ts`** — Unit tests for validation errors and setup transaction encoding

## Usage

```typescript
const safe4337Pack = await Safe4337Pack.init({
  provider,
  signer,
  bundlerUrl,
  options: { owners: [ownerAddress], threshold: 1 },
  erc7579: {
    safe4337ModuleAddress: '0x7579EE8307284F293B1927136486880611F20002',
    launchpadAddress: '0x7579011aB74c46090561ea277Ba79D510c6C00ff',
    attesters: ['0x000000000069E2a187AEFFb852bE3dF9Ea2806DB'],
    attestersThreshold: 1,
    validators: [{ address: validatorAddr, context: initData }],
  },
})
```

## Test plan

- [x] Validation: throws when `safe4337ModuleAddress` is missing
- [x] Validation: throws when `launchpadAddress` is missing
- [x] Validation: throws when no attesters provided
- [x] Setup: enables both 7579 module and launchpad in `enableModules`
- [x] Setup: encodes `initSafe7579` delegatecall with validators/attesters
- [x] Setup: uses 7579 module address as fallbackHandler
