### PR TITLE
fix: support eip1193 provider in the generic fee estimator

### DIFF
--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -57,9 +57,9 @@
   },
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.6.1",
+    "@tetherto/wdk-safe-protocol-kit": "^6.1.3",
     "@safe-global/safe-modules-deployments": "^2.2.21",
     "@safe-global/types-kit": "^3.0.0",
-    "@tetherto/wdk-safe-protocol-kit": "^6.1.3",
     "semver": "^7.7.2",
     "viem": "^2.21.8"
   }

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -60,7 +60,6 @@
     "@safe-global/safe-modules-deployments": "^2.2.21",
     "@safe-global/types-kit": "^3.0.0",
     "@tetherto/wdk-safe-protocol-kit": "^6.1.3",
-    "ethers": "^6.16.0",
     "semver": "^7.7.2",
     "viem": "^2.21.8"
   }

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-safe-relay-kit",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "SDK for Safe Smart Accounts with support for ERC-4337 and Relay",
   "types": "dist/src/index.d.ts",
   "main": "dist/cjs/src/index.cjs",

--- a/packages/relay-kit/package.json
+++ b/packages/relay-kit/package.json
@@ -57,9 +57,10 @@
   },
   "dependencies": {
     "@gelatonetwork/relay-sdk": "^5.6.1",
-    "@tetherto/wdk-safe-protocol-kit": "^6.1.3",
     "@safe-global/safe-modules-deployments": "^2.2.21",
     "@safe-global/types-kit": "^3.0.0",
+    "@tetherto/wdk-safe-protocol-kit": "^6.1.3",
+    "ethers": "^6.16.0",
     "semver": "^7.7.2",
     "viem": "^2.21.8"
   }

--- a/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
+++ b/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, http, toHex } from 'viem'
+import { createPublicClient, Hex, http, RpcBlock, toHex } from 'viem'
 import { EstimateGasData } from '@safe-global/types-kit'
 import { EstimateFeeFunctionProps, IFeeEstimator, UserOperationStringValues } from '../../types'
 import { createBundlerClient, userOperationToHexValues } from '../../utils'
@@ -16,7 +16,7 @@ export type GenericFeeEstimatorOverrides = {
 }
 
 export type GenericEip1193Provider = {
-  request: (args: { method: string; params?: any[] }) => Promise<any>
+  request: (args: { method: string; params?: any[] }) => Promise<unknown>
 }
 
 /**
@@ -180,8 +180,11 @@ export class GenericFeeEstimator implements IFeeEstimator {
   ): Promise<Pick<EstimateGasData, 'maxFeePerGas' | 'maxPriorityFeePerGas'>> {
     const client = typeof rpc === 'string' ? createPublicClient({ transport: http(rpc) }) : rpc
     const [block, maxPriorityFeePerGas] = await Promise.all([
-      client.request({ method: 'eth_getBlockByNumber', params: ['latest', false] }),
-      client.request({ method: 'eth_maxPriorityFeePerGas' })
+      client.request({
+        method: 'eth_getBlockByNumber',
+        params: ['latest', false]
+      }) as Promise<RpcBlock>,
+      client.request({ method: 'eth_maxPriorityFeePerGas' }) as Promise<Hex>
     ])
     // Base fee from the block (can be undefined for non-EIP1559 blocks)
     const baseFeePerGas = block.baseFeePerGas

--- a/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
+++ b/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
@@ -191,7 +191,7 @@ export class GenericFeeEstimator implements IFeeEstimator {
     }
 
     // Calculate maxFeePerGas
-    const maxFeePerGas = baseFeePerGas + maxPriorityFeePerGas
+    const maxFeePerGas = BigInt(baseFeePerGas) + BigInt(maxPriorityFeePerGas)
     return {
       maxFeePerGas: BigInt(
         Math.ceil(Number(maxFeePerGas) * (this.overrides.maxFeePerGasMultiplier ?? 1.5))

--- a/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
+++ b/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
@@ -1,6 +1,5 @@
 import { createPublicClient, http, toHex } from 'viem'
 import { EstimateGasData } from '@safe-global/types-kit'
-import { Eip1193Provider } from 'ethers'
 import { EstimateFeeFunctionProps, IFeeEstimator, UserOperationStringValues } from '../../types'
 import { createBundlerClient, userOperationToHexValues } from '../../utils'
 import { RPC_4337_CALLS } from '../../constants'
@@ -16,6 +15,10 @@ export type GenericFeeEstimatorOverrides = {
   defaultVerificationGasLimitOverhead?: bigint
 }
 
+export type GenericEip1193Provider = {
+  request: (args: { method: string; params?: any[] }) => Promise<any>
+}
+
 /**
  * GenericFeeEstimator is a class that implements the IFeeEstimator interface. You can implement three optional methods that will be called during the estimation process:
  * - preEstimateUserOperationGas: Setup the userOperation before calling the eth_estimateUserOperation gas method.
@@ -24,9 +27,9 @@ export type GenericFeeEstimatorOverrides = {
 export class GenericFeeEstimator implements IFeeEstimator {
   defaultVerificationGasLimitOverhead: bigint
   overrides: GenericFeeEstimatorOverrides
-  rpc: string | Eip1193Provider
+  rpc: string | GenericEip1193Provider
 
-  constructor(rpc: string, overrides: GenericFeeEstimatorOverrides = {}) {
+  constructor(rpc: string | GenericEip1193Provider, overrides: GenericFeeEstimatorOverrides = {}) {
     this.defaultVerificationGasLimitOverhead =
       overrides.defaultVerificationGasLimitOverhead ?? 35_000n
     this.overrides = overrides
@@ -173,14 +176,9 @@ export class GenericFeeEstimator implements IFeeEstimator {
   }
 
   async #getUserOperationGasPrices(
-    rpc: string | Eip1193Provider
+    rpc: string | GenericEip1193Provider
   ): Promise<Pick<EstimateGasData, 'maxFeePerGas' | 'maxPriorityFeePerGas'>> {
-    const client =
-      typeof rpc === 'string'
-        ? createPublicClient({
-            transport: http(rpc)
-          })
-        : rpc
+    const client = typeof rpc === 'string' ? createPublicClient({ transport: http(rpc) }) : rpc
     const [block, maxPriorityFeePerGas] = await Promise.all([
       client.request({ method: 'eth_getBlockByNumber', params: ['latest', false] }),
       client.request({ method: 'eth_maxPriorityFeePerGas' })

--- a/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
+++ b/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
@@ -16,7 +16,7 @@ export type GenericFeeEstimatorOverrides = {
 }
 
 export type GenericEip1193Provider = {
-  request: (args: { method: string; params?: any[] }) => Promise<unknown>
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>
 }
 
 /**

--- a/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
+++ b/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
@@ -1,5 +1,6 @@
 import { createPublicClient, http, toHex } from 'viem'
 import { EstimateGasData } from '@safe-global/types-kit'
+import { Eip1193Provider } from 'ethers'
 import { EstimateFeeFunctionProps, IFeeEstimator, UserOperationStringValues } from '../../types'
 import { createBundlerClient, userOperationToHexValues } from '../../utils'
 import { RPC_4337_CALLS } from '../../constants'
@@ -23,13 +24,13 @@ export type GenericFeeEstimatorOverrides = {
 export class GenericFeeEstimator implements IFeeEstimator {
   defaultVerificationGasLimitOverhead: bigint
   overrides: GenericFeeEstimatorOverrides
-  rpcUrl: string
+  rpc: string | Eip1193Provider
 
-  constructor(rpcUrl: string, overrides: GenericFeeEstimatorOverrides = {}) {
+  constructor(rpc: string, overrides: GenericFeeEstimatorOverrides = {}) {
     this.defaultVerificationGasLimitOverhead =
       overrides.defaultVerificationGasLimitOverhead ?? 35_000n
     this.overrides = overrides
-    this.rpcUrl = rpcUrl
+    this.rpc = rpc
   }
 
   async preEstimateUserOperationGas({
@@ -52,7 +53,7 @@ export class GenericFeeEstimator implements IFeeEstimator {
           : (paymasterOptions.paymasterContext ?? {})
 
       const [feeData, paymasterStubData] = await Promise.all([
-        this.#getUserOperationGasPrices(this.rpcUrl),
+        this.#getUserOperationGasPrices(this.rpc),
         paymasterClient.request({
           method: RPC_4337_CALLS.GET_PAYMASTER_STUB_DATA,
           params: [
@@ -66,7 +67,7 @@ export class GenericFeeEstimator implements IFeeEstimator {
       feeDataRes = feeData
       paymasterStubDataRes = paymasterStubData
     } else {
-      const feeData = await this.#getUserOperationGasPrices(this.rpcUrl)
+      const feeData = await this.#getUserOperationGasPrices(this.rpc)
       feeDataRes = feeData
     }
 
@@ -172,14 +173,17 @@ export class GenericFeeEstimator implements IFeeEstimator {
   }
 
   async #getUserOperationGasPrices(
-    rpcUrl: string
+    rpc: string | Eip1193Provider
   ): Promise<Pick<EstimateGasData, 'maxFeePerGas' | 'maxPriorityFeePerGas'>> {
-    const client = createPublicClient({
-      transport: http(rpcUrl)
-    })
+    const client =
+      typeof rpc === 'string'
+        ? createPublicClient({
+            transport: http(rpc)
+          })
+        : rpc
     const [block, maxPriorityFeePerGas] = await Promise.all([
-      client.getBlock({ blockTag: 'latest' }),
-      client.estimateMaxPriorityFeePerGas()
+      client.request({ method: 'eth_getBlockByNumber', params: ['latest', false] }),
+      client.request({ method: 'eth_maxPriorityFeePerGas' })
     ])
     // Base fee from the block (can be undefined for non-EIP1559 blocks)
     const baseFeePerGas = block.baseFeePerGas

--- a/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
+++ b/packages/relay-kit/src/packs/safe-4337/estimators/generic/GenericFeeEstimator.ts
@@ -179,13 +179,10 @@ export class GenericFeeEstimator implements IFeeEstimator {
     rpc: string | GenericEip1193Provider
   ): Promise<Pick<EstimateGasData, 'maxFeePerGas' | 'maxPriorityFeePerGas'>> {
     const client = typeof rpc === 'string' ? createPublicClient({ transport: http(rpc) }) : rpc
-    const [block, maxPriorityFeePerGas] = await Promise.all([
-      client.request({
-        method: 'eth_getBlockByNumber',
-        params: ['latest', false]
-      }) as Promise<RpcBlock>,
-      client.request({ method: 'eth_maxPriorityFeePerGas' }) as Promise<Hex>
-    ])
+    const [block, maxPriorityFeePerGas] = (await Promise.all([
+      client.request({ method: 'eth_getBlockByNumber', params: ['latest', false] }),
+      client.request({ method: 'eth_maxPriorityFeePerGas' })
+    ])) as [RpcBlock, Hex]
     // Base fee from the block (can be undefined for non-EIP1559 blocks)
     const baseFeePerGas = block.baseFeePerGas
 


### PR DESCRIPTION
## What it solves

Resolves the issue where GenericFeeEstimator only supports RPC URL strings and fails when an EIP-1193 provider instance is passed.

## How this PR fixes it

Adds support for EIP-1193 providers in GenericFeeEstimator, allowing it to work with both RPC URLs and provider instances by using the provider’s request method directly.